### PR TITLE
fix:delete

### DIFF
--- a/app/views/todos/index.html.erb
+++ b/app/views/todos/index.html.erb
@@ -10,8 +10,8 @@
                 <%= todo.title %> <%= todo.introduction%>
             </span>
             <div>
-                <%= link_to "編集", edit_todo_path(todo), class: "edit" %>
-                <%= link_to "削除", todo_path(todo), data: { "turbo-method": :delete }, class: "delete" %>
+                <%= link_to "編集", edit_todo_path(todo), class: "edit" %> 
+                <%= button_to "削除", todo_path(todo), method: :delete , class: "delete" %>
             </div>
         <% end %>
     </ul>

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,13 +5,13 @@ require "rails/all"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
-  
+
 module Controller
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
     #タイムゾーンを東京に設定 # rubocop:disable Layout/LeadingCommentSpace
-    config.time_zone = 'Tokyo'
+    config.time_zone = "Tokyo"
     # デフォルトのロケールを日本語に設定
     config.i18n.default_locale = :ja
     # Please, add to the `ignore` list any other `lib` subdirectories that do


### PR DESCRIPTION
■ 実装したこと
・index.html.erbのdelete機能を書いている場所を link_to から button_to に修正
 → link_to で強引に引数を設定していたが、やっぱりだめらしい

<img width="300" alt="image" src="https://github.com/user-attachments/assets/fd315bf9-37fa-45af-90d5-b06cc65fda26">
<br>
↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
<br>
<img width="300" alt="image" src="https://github.com/user-attachments/assets/cc54510e-13de-40f0-8cf1-8e8e285954cf">
