### PR TITLE
fix:todos_all_todo

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1,4 +1,6 @@
 class TodosController < ApplicationController
+  before_action :set_todo, only: [ :edit, :update, :destroy, :toggle_pin ]
+
   def index
     @todos = Todo.all
   end
@@ -8,7 +10,7 @@ class TodosController < ApplicationController
   end
 
   def create
-    @todo = Todo.create(todo_params)
+    @todo = Todo.new(todo_params)
     if @todo.save
       redirect_to todos_path
     else
@@ -17,11 +19,9 @@ class TodosController < ApplicationController
   end
 
   def edit
-    @todo = Todo.find(params[:id])
   end
 
   def update
-    @todo = Todo.find(params[:id])
     if @todo.update(todo_params)
       redirect_to todos_path
     else
@@ -30,8 +30,12 @@ class TodosController < ApplicationController
   end
 
   def destroy
-    @todo = Todo.find(params[:id])
     @todo.destroy
+    redirect_to todos_path
+  end
+
+  def toggle_pin
+    @todo.toggle(:checkbox).save
     redirect_to todos_path
   end
 
@@ -39,5 +43,10 @@ class TodosController < ApplicationController
 
   def todo_params
     params.require(:todo).permit(:title, :introduction, :checkbox)
+  end
+
+  def set_todo
+    @todo = Todo.find(params[:id])
+    redirect_to todo_url, status: :see_other if @todo.nil?
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
   root to: "todos#index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-  resources :todos, only: [ :index, :new, :create, :edit, :update, :destroy ]
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   # get "up" => "rails/health#show", as: :rails_health_check
@@ -12,4 +11,9 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+  resources :todos, only: [ :index, :new, :create, :edit, :update, :destroy ] do
+    member do
+      patch :toggle_pin # PATCH /todos/:id/toggle_pin
+    end
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_31_064335) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "introduction"
-    t.boolean "checkbox", default: false
+    t.boolean "checkbox", default: false , null: false
   end
 end


### PR DESCRIPTION
■ 実装したこと
・before_action で"@todo = Todo.find(params[:id])"を統合して扱えるようにした。
・固定機能や達成成否をやりやすくするために"toggle_pin"として扱えるようにした。
■ 課題
・"toggle_pin"を実装したが、modelが全く適用されてないためトグルするとエラーを起こす
 → modelの方をどうにかするとよいかも。それか、add_checkbox_to_todosを、変数として管理する方が楽かも